### PR TITLE
Fix code scanning alert no. 3: Regular expression injection

### DIFF
--- a/app/utils/posthog.server.ts
+++ b/app/utils/posthog.server.ts
@@ -1,9 +1,11 @@
 import PostHogClient from "../posthog";
+import _ from 'lodash';
 
 export function capturePosthogEvent(request: Request, eventName: string) {
     const cookieString = request.headers.get('Cookie') || '';  
     const projectAPIKey = process.env.POSTHOG_API_KEY;
-    const cookieName = `ph_${projectAPIKey}_posthog`;
+    const safeProjectAPIKey = _.escapeRegExp(projectAPIKey);
+    const cookieName = `ph_${safeProjectAPIKey}_posthog`;
     const cookieMatch = cookieString.match(new RegExp(cookieName + '=([^;]+)'));
     let distinctId;
   

--- a/package.json
+++ b/package.json
@@ -114,7 +114,8 @@
     "tailwindcss-animate": "^1.0.7",
     "tailwindcss-radix": "^3.0.3",
     "vite-env-only": "^3.0.3",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@epic-web/config": "^1.12.0",


### PR DESCRIPTION
Fixes [https://github.com/carlulsoe/stellar-spire/security/code-scanning/3](https://github.com/carlulsoe/stellar-spire/security/code-scanning/3)

To fix the problem, we need to sanitize the `projectAPIKey` before using it to construct the regular expression. The best way to do this is by using a sanitization function such as `_.escapeRegExp` from the lodash library. This function escapes special characters in the input string, making it safe to use in a regular expression.

- Import the `lodash` library.
- Use the `_.escapeRegExp` function to sanitize `projectAPIKey` before constructing the regular expression.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
